### PR TITLE
Dispose highlighted materials

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -232,7 +232,7 @@ function highlightWinCells(cells) {
     const oldScale = m.scale.clone();
     m.scale.set(oldScale.x * 1.12, oldScale.y * 1.12, oldScale.z * 1.12);
 
-    highlighted.push({ mesh: m, matOld, scaleOld: oldScale });
+    highlighted.push({ mesh: m, matOld, matNew, scaleOld: oldScale });
   }
 }
 
@@ -243,6 +243,9 @@ function clearWinHighlight() {
       if (h.mesh) {
         if (h.matOld) h.mesh.material = h.matOld;
         if (h.scaleOld) h.mesh.scale.copy(h.scaleOld);
+      }
+      if (h.matNew && typeof h.matNew.dispose === 'function') {
+        h.matNew.dispose();
       }
     } catch {}
   }


### PR DESCRIPTION
## Summary
- retain cloned materials in `highlighted` for proper cleanup
- dispose of highlight materials when clearing win state, guarding absent `dispose`

## Testing
- `node --check src/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f35a25ac832ea729b00c04045ab1