### PR TITLE
Add persistent game state with storage controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <button id="btnReset" class="btn">Neu/Reset</button>
         <button id="btnUndo1" class="btn">Undo 1</button>
         <button id="btnUndo2" class="btn">Undo 2</button>
+        <button id="btnClear" class="btn">Speicher löschen</button>
 
         <label class="lb">KI:
           <select id="aiMode">


### PR DESCRIPTION
## Summary
- Restore saved games on startup, including AI options and board state
- Persist game state after moves, resets, undos and allow clearing stored data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f35297a4832ead4800043f3475fe