### PR TITLE
Use explicit server host for network requests

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const SERVER_HOST = `${location.hostname}:3000`;

--- a/src/net.js
+++ b/src/net.js
@@ -1,3 +1,5 @@
+import { SERVER_HOST } from './config.js';
+
 let ws = null;
 const handlers = [];
 let pingTimer = null;
@@ -6,7 +8,7 @@ function emit(msg) { for (const h of handlers) { try { h(msg); } catch {} } }
 
 export function connect(code) {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  const url = `${proto}://${location.host}/ws?code=${code}`;
+  const url = `${proto}://${SERVER_HOST}/ws?code=${code}`;
   ws = new WebSocket(url);
   ws.onopen = () => {
     startPing();

--- a/src/ui.js
+++ b/src/ui.js
@@ -2,6 +2,7 @@
 // Usage: initDropdown(el, { onChange: (value,label)=>{} }); setDropdownValue(el, value)
 
 import * as net from './net.js';
+import { SERVER_HOST } from './config.js';
 
 export function initDropdown(el, { onChange } = {}) {
   const btn  = el.querySelector('.dd-btn');
@@ -65,7 +66,8 @@ export function initNetControls() {
 
   btnCreate?.addEventListener('click', async () => {
     try {
-      const res = await fetch('/room', { method: 'POST' });
+      const scheme = location.protocol === 'https:' ? 'https://' : 'http://';
+      const res = await fetch(`${scheme}${SERVER_HOST}/room`, { method: 'POST' });
       const data = await res.json();
       if (lblCode) lblCode.textContent = data.code;
       net.connect(data.code);


### PR DESCRIPTION
## Summary
- Add shared `SERVER_HOST` constant to point clients to port 3000
- Use `SERVER_HOST` when creating rooms via `fetch`
- Use `SERVER_HOST` for WebSocket connections

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd server && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab405da510832ea72877d9b4695850