### PR TITLE
Serve static assets from server and use relative host

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const http = require('http');
+const path = require('path');
 const { WebSocketServer } = require('ws');
 
 const app = express();
@@ -22,6 +23,7 @@ function generateCode() {
 }
 
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '..')));
 
 app.post('/room', (_req, res) => {
   const code = generateCode();

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,1 @@
-export const SERVER_HOST = `${location.hostname}:3000`;
+export const SERVER_HOST = location.host;


### PR DESCRIPTION
## Summary
- Serve project files through `express.static` in the Node server
- Use `location.host` so client connections automatically match the served host

## Testing
- `npm test` *(fails: Missing script "test")*
- `node index.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68ab40f51a88832e956956e7597a0ec0