### PR TITLE
Specify server host port

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,4 @@
-export const SERVER_HOST = location.host;
+// Determine the server host used for network requests.
+// If the frontend is served from a different port than the backend,
+// adjust the port value below accordingly.
+export const SERVER_HOST = `${location.hostname}:3000`;


### PR DESCRIPTION
## Summary
- ensure network calls target backend by specifying server host with explicit port

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab449ea938832ebb698149c4ccd4d6