### PR TITLE
Add configurable server protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Four Wins
+
+Simple Connect Four game with network play.
+
+## Server Configuration
+
+Network requests use constants defined in `src/config.js`.
+
+- `SERVER_PROTOCOL` – either `http` or `https`. It defaults to the protocol used
+  by the page (`location.protocol`).
+- `SERVER_HOST` – base URL of the backend, combining protocol, host and port.
+
+### Deployment
+
+When deploying locally without TLS, `SERVER_PROTOCOL` resolves to `http` and the
+client connects via `ws://` for WebSockets. For secure deployments served over
+HTTPS, the protocol becomes `https` and WebSockets use `wss://` automatically.
+
+If your deployment requires a specific protocol regardless of the page's
+protocol, adjust `SERVER_PROTOCOL` in `src/config.js` accordingly before
+building the frontend.

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 // Determine the server host used for network requests.
 // If the frontend is served from a different port than the backend,
 // adjust the port value below accordingly.
-export const SERVER_HOST = `${location.hostname}:3000`;
+export const SERVER_PROTOCOL = location.protocol === 'https:' ? 'https' : 'http';
+export const SERVER_HOST = `${SERVER_PROTOCOL}://${location.hostname}:3000`;

--- a/src/net.js
+++ b/src/net.js
@@ -7,8 +7,7 @@ let pingTimer = null;
 function emit(msg) { for (const h of handlers) { try { h(msg); } catch {} } }
 
 export function connect(code) {
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  const url = `${proto}://${SERVER_HOST}/ws?code=${code}`;
+  const url = `${SERVER_HOST.replace(/^http/, 'ws')}/ws?code=${code}`;
   ws = new WebSocket(url);
   ws.onopen = () => {
     startPing();

--- a/src/ui.js
+++ b/src/ui.js
@@ -66,8 +66,7 @@ export function initNetControls() {
 
   btnCreate?.addEventListener('click', async () => {
     try {
-      const scheme = location.protocol === 'https:' ? 'https://' : 'http://';
-      const res = await fetch(`${scheme}${SERVER_HOST}/room`, { method: 'POST' });
+      const res = await fetch(`${SERVER_HOST}/room`, { method: 'POST' });
       const data = await res.json();
       if (lblCode) lblCode.textContent = data.code;
       net.connect(data.code);


### PR DESCRIPTION
## Summary
- add `SERVER_PROTOCOL` constant and prepend protocol to `SERVER_HOST`
- use unified `SERVER_HOST` for HTTP and WebSocket requests
- document setting `SERVER_PROTOCOL` for deployments

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab47c2ff24832eba27c8a9ded7449a