### PR TITLE
feat: allow custom server protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,28 @@ Simple Connect Four game with network play.
 
 Network requests use constants defined in `src/config.js`.
 
-- `SERVER_PROTOCOL` – either `http` or `https`. It defaults to the protocol used
-  by the page (`location.protocol`).
+- `SERVER_PROTOCOL` – either `http` or `https`. It can be set via
+  `window.SERVER_CONFIG.protocol` or the `DEFAULT_PROTOCOL` constant. If neither
+  is provided, it falls back to the page's protocol (`location.protocol`).
+- `SERVER_PORT` – backend port. Configure it through
+  `window.SERVER_CONFIG.port` or the `DEFAULT_PORT` constant (defaults to `3000`).
 - `SERVER_HOST` – base URL of the backend, combining protocol, host and port.
 
 ### Deployment
 
-When deploying locally without TLS, `SERVER_PROTOCOL` resolves to `http` and the
-client connects via `ws://` for WebSockets. For secure deployments served over
-HTTPS, the protocol becomes `https` and WebSockets use `wss://` automatically.
+When deploying locally without TLS, `SERVER_PROTOCOL` will use the page's
+protocol (`http`) and connect via `ws://` for WebSockets. For secure deployments
+served over HTTPS, the protocol becomes `https` and WebSockets use `wss://`
+automatically.
 
-If your deployment requires a specific protocol regardless of the page's
-protocol, adjust `SERVER_PROTOCOL` in `src/config.js` accordingly before
-building the frontend.
+If your deployment requires a specific protocol or port regardless of the
+page's settings, either define them before loading the bundle:
+
+```html
+<script>
+  window.SERVER_CONFIG = { protocol: 'https', port: 443 };
+</script>
+```
+
+or edit `DEFAULT_PROTOCOL` and `DEFAULT_PORT` in `src/config.js` before building
+the frontend.

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,15 @@
 // Determine the server host used for network requests.
-// If the frontend is served from a different port than the backend,
-// adjust the port value below accordingly.
-export const SERVER_PROTOCOL = location.protocol === 'https:' ? 'https' : 'http';
-export const SERVER_HOST = `${SERVER_PROTOCOL}://${location.hostname}:3000`;
+// `SERVER_PROTOCOL` and the backend port can be configured either via a global
+// `window.SERVER_CONFIG` object or by editing the constants below. If no value
+// is provided, the protocol falls back to the current page's protocol.
+
+const DEFAULT_PROTOCOL = undefined; // e.g. 'http' or 'https'
+const DEFAULT_PORT = 3000;
+
+const PROTOCOL_OVERRIDE = window.SERVER_CONFIG?.protocol ?? DEFAULT_PROTOCOL;
+const PORT_OVERRIDE = window.SERVER_CONFIG?.port ?? DEFAULT_PORT;
+
+export const SERVER_PROTOCOL =
+  PROTOCOL_OVERRIDE || (location.protocol === 'https:' ? 'https' : 'http');
+export const SERVER_PORT = PORT_OVERRIDE;
+export const SERVER_HOST = `${SERVER_PROTOCOL}://${location.hostname}:${SERVER_PORT}`;


### PR DESCRIPTION
## Summary
- allow overriding server protocol and port via `window.SERVER_CONFIG` or constants
- document how to configure protocol and port for different deployments

## Testing
- `npm test --prefix server` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a12745c832e85c9ff75ff0915cd