### PR TITLE
fix remote move relay in FourWins server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -117,7 +117,7 @@ wss.on('connection', (ws, room, code) => {
 
         room.players.forEach(p => {
             if (p !== ws && p.readyState === p.OPEN) {
-                p.send(msg);
+                p.send(JSON.stringify(data));
             }
         });
     });


### PR DESCRIPTION
## Summary
- Ensure WebSocket relay sends JSON text frames so clients can parse messages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd server && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab6124e3e4832ea40e3e719c5de1bf