### PR TITLE
feat: add board hint

### DIFF
--- a/assets/connect4-board.svg
+++ b/assets/connect4-board.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 260">
+  <rect width="300" height="260" fill="#0b1020" rx="8"/>
+  <g fill="none" stroke="#22ff88" stroke-width="4">
+  <circle cx="20" cy="20" r="18"/>
+  <circle cx="60" cy="20" r="18"/>
+  <circle cx="100" cy="20" r="18"/>
+  <circle cx="140" cy="20" r="18"/>
+  <circle cx="180" cy="20" r="18"/>
+  <circle cx="220" cy="20" r="18"/>
+  <circle cx="260" cy="20" r="18"/>
+  <circle cx="20" cy="60" r="18"/>
+  <circle cx="60" cy="60" r="18"/>
+  <circle cx="100" cy="60" r="18"/>
+  <circle cx="140" cy="60" r="18"/>
+  <circle cx="180" cy="60" r="18"/>
+  <circle cx="220" cy="60" r="18"/>
+  <circle cx="260" cy="60" r="18"/>
+  <circle cx="20" cy="100" r="18"/>
+  <circle cx="60" cy="100" r="18"/>
+  <circle cx="100" cy="100" r="18"/>
+  <circle cx="140" cy="100" r="18"/>
+  <circle cx="180" cy="100" r="18"/>
+  <circle cx="220" cy="100" r="18"/>
+  <circle cx="260" cy="100" r="18"/>
+  <circle cx="20" cy="140" r="18"/>
+  <circle cx="60" cy="140" r="18"/>
+  <circle cx="100" cy="140" r="18"/>
+  <circle cx="140" cy="140" r="18"/>
+  <circle cx="180" cy="140" r="18"/>
+  <circle cx="220" cy="140" r="18"/>
+  <circle cx="260" cy="140" r="18"/>
+  <circle cx="20" cy="180" r="18"/>
+  <circle cx="60" cy="180" r="18"/>
+  <circle cx="100" cy="180" r="18"/>
+  <circle cx="140" cy="180" r="18"/>
+  <circle cx="180" cy="180" r="18"/>
+  <circle cx="220" cy="180" r="18"/>
+  <circle cx="260" cy="180" r="18"/>
+  <circle cx="20" cy="220" r="18"/>
+  <circle cx="60" cy="220" r="18"/>
+  <circle cx="100" cy="220" r="18"/>
+  <circle cx="140" cy="220" r="18"/>
+  <circle cx="180" cy="220" r="18"/>
+  <circle cx="220" cy="220" r="18"/>
+  <circle cx="260" cy="220" r="18"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -117,6 +117,10 @@
     </main>
   </div>
 
+  <aside class="four-hint">
+    <img src="assets/connect4-board.svg" alt="Vier gewinnt Spielfeld" />
+  </aside>
+
   <script type="module">
     import './src/main.js';
   </script>

--- a/styles.css
+++ b/styles.css
@@ -79,3 +79,27 @@ select {
   -webkit-user-select: auto;
   user-select: auto;
 }
+
+.four-hint {
+  position:absolute;
+  top:0;
+  right:0;
+  width:50%;
+  height:100%;
+  display:flex;
+  justify-content:center;
+  align-items:center;
+}
+
+.four-hint img {
+  max-width:100%;
+  height:auto;
+}
+
+@media (max-width: 600px) {
+  .four-hint {
+    position:static;
+    width:100%;
+    margin-top:1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- show a static Connect Four board hint on the right side
- style hint panel with responsive media query
- include board SVG asset

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/fourwins/package.json')
- `cd server && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68ab720e5810832eb773ab32faf7f477