### PR TITLE
Add AR result sign and XR session cleanup

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -128,6 +128,7 @@ export function getBoardObject()  { return boardObj; }
 export function getBoardState()   { return boardState; }
 export function getCurrentPlayer(){ return currentPlayer; }
 export function isGameOver()      { return gameOver; }
+export function getMyPlayer()     { return myPlayer; }
 export function getAiOptions()    { return { enabled: aiEnabled, ...aiOptions }; }
 export function setAiOptions(o) {
   if (!o) return;


### PR DESCRIPTION
## Summary
- expose local player through `getMyPlayer`
- show win/lose/draw result sign in AR and end session after a delay
- clean up board and sign when XR session ends

## Testing
- `npm test` *(fails: no package.json)*
- `npm test --prefix server` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acb0d08548832e99ebd42bcf8da7a0