### PR TITLE
Ensure HUD is shown after XR session ends

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -87,6 +87,13 @@ function init() {
     boardPlaced = false;
     const ret = getReticle();
     if (ret) ret.visible = true;
+    const hud = document.getElementById('hud');
+    if (hud) {
+      hud.style.display = 'block';
+      hud.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      location.reload();
+    }
   });
 
   // Scene & Camera


### PR DESCRIPTION
## Summary
- Show configuration controls again when an XR session closes

## Testing
- `npm test --prefix server` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acba521a4c832ea2a6be755a30f986