### PR TITLE
Raise result sign above board

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ function showResultSign(text, color) {
   const geometry = new THREE.PlaneGeometry(0.6, 0.3);
   resultSign = new THREE.Mesh(geometry, material);
   resultSign.position.copy(boardRoot.position);
-  resultSign.position.y += 0.35;
+  resultSign.position.y += 0.7;
   resultSign.quaternion.copy(camera.quaternion);
   scene.add(resultSign);
 }


### PR DESCRIPTION
## Summary
- move victory/defeat banner higher so final move remains visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbc64e6bc832e9818c3a9d0f07fca